### PR TITLE
title to xlink:title in <dao> tags

### DIFF
--- a/ArchivesSpace-EAD-validator.sch
+++ b/ArchivesSpace-EAD-validator.sch
@@ -123,7 +123,7 @@ for the time being, i removed namespace checks so that the same rules will work 
 
     <pattern id="checking_dao_expectations">
         <rule context="*:dao">
-            <assert test="self::*/@title">ASpace requires that every dao have a title attribute</assert>
+            <assert test="self::*/@xlink:title">ASpace requires that every dao have a title attribute</assert>
         </rule>
     </pattern>
 


### PR DESCRIPTION
Fixing issue #9 where the Schematron misidentifies xlink:title tags in <dao>s as invalid and title attributes without "xlink:" as valid. 